### PR TITLE
adding build script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 dist
+yarn.lock
+package-lock.json

--- a/build_protos.sh
+++ b/build_protos.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+#check if yarn has been installed
+#regex match the word success
+if [[ $(yarn check) =~ "success" ]]; then
+    echo "GRPC dependencies are installed."
+else
+    echo "Dependency yarn is not installed. Please install yarn and try again."
+    #Ask user y/n to install dependencies
+    read -p "Install dependencies? (y/n) " -n 1 -r
+    #if user says no exit else run "yarn install"
+    if [[ ! $REPLY =~ ^[Yy]$ ]]
+    then
+        echo "Exiting..."
+        exit 1
+    else
+        echo "Installing dependencies..."
+        yarn install
+    fi
+fi
+
+
+PROTO_DIR=./protos
+PROTO_FILE=$PROTO_DIR/taro.proto
+if [ "$#" -ne 1 ]; then
+    echo "No argument supplied, using default path: $PROTO_FILE"
+else
+    echo "Using custom proto file: $1"
+    #check if file exists
+    if ! [ -f "$1" ]; then
+        echo "Proto file $1 does not exist"
+        exit 1
+    fi
+    PROTO_FILE=$1
+fi
+
+#Generate Javascript code
+yarn proto-loader-gen-types --grpcLib=@grpc/grpc-js --longs=String --enums=String --defaults --oneofs --keepCase --outDir=./src/types $PROTO_FILE

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "publish": "tsc && npm publish --access public",
     "build": "tsc",
-    "generate:types": "./node_modules/.bin/proto-loader-gen-types --longs=String --enums=String --defaults --oneofs --grpcLib=@grpc/grpc-js --outDir=./src/types/ protos/*.proto"
+    "generate:types": "./build_protos.sh"
   },
   "author": {
     "name": "Ricardo Alonzo"
@@ -21,13 +21,19 @@
   "license": "MIT",
   "dependencies": {
     "@grpc/grpc-js": "1.7.2",
-    "@grpc/proto-loader": "0.7.3"
+    "@grpc/proto-loader": "0.7.3",
+    "grpc": "^1.24.11"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hodlone/taro-api.git"
   },
   "devDependencies": {
-    "typescript": "4.8.4"
+    "typescript": "4.8.4",
+    "@types/google-protobuf": "^3.15.6",
+    "grpc-tools": "^1.12.3",
+    "grpc_tools_node_protoc_ts": "^5.3.2"
+
+
   }
 }


### PR DESCRIPTION
yarn generate:types now takes an argument to a proto file.

I'm currently adding a getinfo command to taro. 
I need this API to add taro to [@jamal polar](https://github.com/jamaljsr/polar), this just adds a little bit of agility to development when adding or changing rpc commands in taro.