### PR TITLE
Load proto with the same options as the generated types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,12 @@ export class TaroApi {
     };
 
     const protoPath = Path.join(__dirname, "../protos", "taro.proto");
-    const packageDefinition = protoLoader.loadSync(protoPath);
+    const packageDefinition = protoLoader.loadSync(protoPath, {
+      longs: String,
+      enums: String,
+      defaults: true,
+      oneofs: true,
+    });
     const proto = grpc.loadPackageDefinition(
       packageDefinition
     ) as unknown as ProtoGrpcType;


### PR DESCRIPTION
This PR adds the `protoLoader.loadSync` options so that the JS code at runtime matches the static types that are provided by this library. 

Currently, the golang `uint64` fields are being returned as `Long`s instead of `string`s and enums are `number`s instead of `string`s. The runtime values are different than the TS types.

The options should stay in sync with the ones that the `proto-loader-gen-types` command in `package.json` uses.