### PR TITLE
Update taro.proto and generated types

### DIFF
--- a/protos/taro.proto
+++ b/protos/taro.proto
@@ -16,6 +16,18 @@ service Taro {
     */
     rpc ListAssets (ListAssetRequest) returns (ListAssetResponse);
 
+    /* tarocli: `assets utxos`
+    ListUtxos lists the UTXOs managed by the target daemon, and the assets they
+    hold.
+    */
+    rpc ListUtxos (ListUtxosRequest) returns (ListUtxosResponse);
+
+    /* tarocli: `assets groups`
+    ListGroups lists the asset groups known to the target daemon, and the assets
+    held in each group.
+    */
+    rpc ListGroups (ListGroupsRequest) returns (ListGroupsResponse);
+
     /* tarocli: `assets balance`
     ListBalances lists asset balances
     */
@@ -93,13 +105,13 @@ enum AssetType {
     /*
     Indicates that an asset is capable of being split/merged, with each of the
     units being fungible, even across a key asset ID boundary (assuming the
-    key family is the same).
+    key group is the same).
     */
     NORMAL = 0;
 
     /*
     Indicates that an asset is a collectible, meaning that each of the other
-    items under the same key family are not fully fungible with each other.
+    items under the same key group are not fully fungible with each other.
     Collectibles also cannot be split or merged.
     */
     COLLECTIBLE = 1;
@@ -124,7 +136,7 @@ message MintAssetRequest {
     int64 amount = 4;
 
     /*
-    If true, then the asset will be created with a key family, which allows for
+    If true, then the asset will be created with a key group, which allows for
     future asset issuance.
     */
     bool enable_emission = 5;
@@ -196,15 +208,15 @@ message GenesisInfo {
     int32 version = 7;
 }
 
-message AssetFamily {
-    // The raw family key which is a normal public key.
-    bytes raw_family_key = 1;
+message AssetGroup {
+    // The raw group key which is a normal public key.
+    bytes raw_group_key = 1;
 
     /*
-    The tweaked family key, which is derived based on the genesis point and also
+    The tweaked group key, which is derived based on the genesis point and also
     asset type.
     */
-    bytes tweaked_family_key = 2;
+    bytes tweaked_group_key = 2;
 
     // A signature over the genesis point using the above key.
     bytes asset_id_sig = 3;
@@ -235,8 +247,8 @@ message Asset {
     // The script key of the asset, which can be spent under Taproot semantics.
     bytes script_key = 9;
 
-    // The information related to the key family of an asset (if it exists).
-    AssetFamily asset_family = 10;
+    // The information related to the key group of an asset (if it exists).
+    AssetGroup asset_group = 10;
 
     // Describes where in the chain the asset is currently anchored.
     AnchorInfo chain_anchor = 11;
@@ -246,23 +258,84 @@ message ListAssetResponse {
     repeated Asset assets = 1;
 }
 
+message ListUtxosRequest {
+}
+
+message ManagedUtxo {
+    // The outpoint of the UTXO.
+    string out_point = 1;
+
+    // The UTXO amount in satoshis.
+    int64 amt_sat = 2;
+
+    // The internal key used for the on-chain output.
+    bytes internal_key = 3;
+
+    // The Taro root that commits to the set of assets at this UTXO.
+    bytes taro_root = 4;
+
+    // The assets held at this UTXO.
+    repeated Asset assets = 5;
+}
+
+message ListUtxosResponse {
+    // The set of UTXOs managed by the daemon.
+    map<string, ManagedUtxo> managed_utxos = 1;
+}
+
+message ListGroupsRequest {
+}
+
+message AssetHumanReadable {
+    // The ID of the asset.
+    bytes id = 1;
+
+    // The amount of the asset.
+    uint64 amount = 2;
+
+    // An optional locktime, as with Bitcoin transactions.
+    int32 lock_time = 3;
+
+    // An optional relative locktime, as with Bitcoin transactions.
+    int32 relative_lock_time = 4;
+
+    // The name of the asset.
+    string tag = 5;
+
+    // The opaque metadata of the asset.
+    bytes meta_data = 6;
+
+    // The type of the asset.
+    AssetType type = 7;
+}
+
+message GroupedAssets {
+    // A list of assets with the same group key.
+    repeated AssetHumanReadable assets = 1;
+}
+
+message ListGroupsResponse {
+    // The set of assets with a group key.
+    map<string, GroupedAssets> groups = 1;
+}
+
 message ListBalancesRequest {
     oneof group_by {
         // Group results by asset IDs.
         bool asset_id = 1;
 
-        // Group results by family keys.
-        bool fam_key = 2;
+        // Group results by group keys.
+        bool group_key = 2;
     }
 
     // If the query results should grouped by asset ids, then an optional asset
     // filter may be provided to query balance of a specific asset.
     bytes asset_filter = 3;
 
-    // If the query results should be grouped by family keys, then an optional
-    // family key filter may be provided to query the balance of a specific
-    // asset family.
-    bytes family_key_filter = 4;
+    // If the query results should be grouped by group keys, then an optional
+    // group key filter may be provided to query the balance of a specific
+    // asset group.
+    bytes group_key_filter = 4;
 }
 
 message AssetBalance {
@@ -276,18 +349,18 @@ message AssetBalance {
     int64 balance = 3;
 }
 
-message AssetFamilyBalance {
-    // The family key or nil aggregating assets that don't have a family.
-    bytes family_key = 1;
+message AssetGroupBalance {
+    // The group key or nil aggregating assets that don't have a group.
+    bytes group_key = 1;
 
-    // The total balance of the assets in the family.
+    // The total balance of the assets in the group.
     int64 balance = 2;
 }
 
 message ListBalancesResponse {
     map<string, AssetBalance> asset_balances = 1;
 
-    map<string, AssetFamilyBalance> asset_family_balances = 2;
+    map<string, AssetGroupBalance> asset_group_balances = 2;
 }
 
 message ListTransfersRequest {
@@ -366,8 +439,8 @@ message Addr {
     // The total amount of the asset stored in this Taro UTXO.
     int64 amount = 4;
 
-    // The family key of the asset (if it exists)
-    bytes family_key = 5;
+    // The group key of the asset (if it exists)
+    bytes group_key = 5;
 
     /*
     The specific script key the asset must commit to in order to transfer
@@ -413,7 +486,7 @@ message QueryAddrResponse {
 message NewAddrRequest {
     bytes genesis_bootstrap_info = 1;
 
-    bytes fam_key = 2;
+    bytes group_key = 2;
 
     int64 amt = 3;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ import { TaroClient } from "./types/tarorpc/Taro";
 import { ListAssetResponse__Output } from "./types/tarorpc/ListAssetResponse";
 import { ListBalancesRequest } from "./types/tarorpc/ListBalancesRequest";
 import { ListBalancesResponse__Output } from "./types/tarorpc/ListBalancesResponse";
+import { ListGroupsResponse__Output } from "./types/tarorpc/ListGroupsResponse";
+import { ListUtxosResponse__Output } from "./types/tarorpc/ListUtxosResponse";
 import { MintAssetRequest } from "./types/tarorpc/MintAssetRequest";
 import { MintAssetResponse__Output } from "./types/tarorpc/MintAssetResponse";
 import { DebugLevelRequest } from "./types/tarorpc/DebugLevelRequest";
@@ -155,6 +157,21 @@ export class TaroApi {
   }
 
   /**
+   * @listGroups ListGroups lists the asset groups known to
+   * the target daemon, and the assets held in each group.
+   */
+
+  async listGroups(): Promise<ListGroupsResponse__Output> {
+    return new Promise((resolve, reject) => {
+      this.client.ListGroups({}, (error, response) => {
+        if (error) reject(error);
+
+        resolve(<ListGroupsResponse__Output>response);
+      });
+    });
+  }
+
+  /**
    * @listTransfers ListTransfers lists asset transfers.
    */
 
@@ -164,6 +181,21 @@ export class TaroApi {
         if (error) reject(error);
 
         resolve(<ListTransfersResponse__Output>response);
+      });
+    });
+  }
+
+  /**
+   * @listUtxos ListUtxos lists the UTXOs managed by the
+   * target daemon, and the assets they hold.
+   */
+
+  async listUtxos(): Promise<ListUtxosResponse__Output> {
+    return new Promise((resolve, reject) => {
+      this.client.ListUtxos({}, (error, response) => {
+        if (error) reject(error);
+
+        resolve(<ListUtxosResponse__Output>response);
       });
     });
   }

--- a/src/types/taro.ts
+++ b/src/types/taro.ts
@@ -17,8 +17,9 @@ export interface ProtoGrpcType {
     AnchorInfo: MessageTypeDefinition
     Asset: MessageTypeDefinition
     AssetBalance: MessageTypeDefinition
-    AssetFamily: MessageTypeDefinition
-    AssetFamilyBalance: MessageTypeDefinition
+    AssetGroup: MessageTypeDefinition
+    AssetGroupBalance: MessageTypeDefinition
+    AssetHumanReadable: MessageTypeDefinition
     AssetOutput: MessageTypeDefinition
     AssetSpendDelta: MessageTypeDefinition
     AssetTransfer: MessageTypeDefinition
@@ -28,14 +29,20 @@ export interface ProtoGrpcType {
     DecodeAddrRequest: MessageTypeDefinition
     ExportProofRequest: MessageTypeDefinition
     GenesisInfo: MessageTypeDefinition
+    GroupedAssets: MessageTypeDefinition
     ImportProofRequest: MessageTypeDefinition
     ImportProofResponse: MessageTypeDefinition
     ListAssetRequest: MessageTypeDefinition
     ListAssetResponse: MessageTypeDefinition
     ListBalancesRequest: MessageTypeDefinition
     ListBalancesResponse: MessageTypeDefinition
+    ListGroupsRequest: MessageTypeDefinition
+    ListGroupsResponse: MessageTypeDefinition
     ListTransfersRequest: MessageTypeDefinition
     ListTransfersResponse: MessageTypeDefinition
+    ListUtxosRequest: MessageTypeDefinition
+    ListUtxosResponse: MessageTypeDefinition
+    ManagedUtxo: MessageTypeDefinition
     MintAssetRequest: MessageTypeDefinition
     MintAssetResponse: MessageTypeDefinition
     NewAddrRequest: MessageTypeDefinition

--- a/src/types/tarorpc/Addr.ts
+++ b/src/types/tarorpc/Addr.ts
@@ -8,7 +8,7 @@ export interface Addr {
   'assetId'?: (Buffer | Uint8Array | string);
   'assetType'?: (_tarorpc_AssetType | keyof typeof _tarorpc_AssetType);
   'amount'?: (number | string | Long);
-  'familyKey'?: (Buffer | Uint8Array | string);
+  'groupKey'?: (Buffer | Uint8Array | string);
   'scriptKey'?: (Buffer | Uint8Array | string);
   'internalKey'?: (Buffer | Uint8Array | string);
   'taprootOutputKey'?: (Buffer | Uint8Array | string);
@@ -19,7 +19,7 @@ export interface Addr__Output {
   'assetId': (Buffer);
   'assetType': (keyof typeof _tarorpc_AssetType);
   'amount': (string);
-  'familyKey': (Buffer);
+  'groupKey': (Buffer);
   'scriptKey': (Buffer);
   'internalKey': (Buffer);
   'taprootOutputKey': (Buffer);

--- a/src/types/tarorpc/Asset.ts
+++ b/src/types/tarorpc/Asset.ts
@@ -2,7 +2,7 @@
 
 import type { GenesisInfo as _tarorpc_GenesisInfo, GenesisInfo__Output as _tarorpc_GenesisInfo__Output } from '../tarorpc/GenesisInfo';
 import type { AssetType as _tarorpc_AssetType } from '../tarorpc/AssetType';
-import type { AssetFamily as _tarorpc_AssetFamily, AssetFamily__Output as _tarorpc_AssetFamily__Output } from '../tarorpc/AssetFamily';
+import type { AssetGroup as _tarorpc_AssetGroup, AssetGroup__Output as _tarorpc_AssetGroup__Output } from '../tarorpc/AssetGroup';
 import type { AnchorInfo as _tarorpc_AnchorInfo, AnchorInfo__Output as _tarorpc_AnchorInfo__Output } from '../tarorpc/AnchorInfo';
 import type { Long } from '@grpc/proto-loader';
 
@@ -15,7 +15,7 @@ export interface Asset {
   'relativeLockTime'?: (number);
   'scriptVersion'?: (number);
   'scriptKey'?: (Buffer | Uint8Array | string);
-  'assetFamily'?: (_tarorpc_AssetFamily | null);
+  'assetGroup'?: (_tarorpc_AssetGroup | null);
   'chainAnchor'?: (_tarorpc_AnchorInfo | null);
 }
 
@@ -28,6 +28,6 @@ export interface Asset__Output {
   'relativeLockTime': (number);
   'scriptVersion': (number);
   'scriptKey': (Buffer);
-  'assetFamily': (_tarorpc_AssetFamily__Output | null);
+  'assetGroup': (_tarorpc_AssetGroup__Output | null);
   'chainAnchor': (_tarorpc_AnchorInfo__Output | null);
 }

--- a/src/types/tarorpc/AssetGroup.ts
+++ b/src/types/tarorpc/AssetGroup.ts
@@ -1,0 +1,14 @@
+// Original file: protos/taro.proto
+
+
+export interface AssetGroup {
+  'rawGroupKey'?: (Buffer | Uint8Array | string);
+  'tweakedGroupKey'?: (Buffer | Uint8Array | string);
+  'assetIdSig'?: (Buffer | Uint8Array | string);
+}
+
+export interface AssetGroup__Output {
+  'rawGroupKey': (Buffer);
+  'tweakedGroupKey': (Buffer);
+  'assetIdSig': (Buffer);
+}

--- a/src/types/tarorpc/AssetGroupBalance.ts
+++ b/src/types/tarorpc/AssetGroupBalance.ts
@@ -1,0 +1,13 @@
+// Original file: protos/taro.proto
+
+import type { Long } from '@grpc/proto-loader';
+
+export interface AssetGroupBalance {
+  'groupKey'?: (Buffer | Uint8Array | string);
+  'balance'?: (number | string | Long);
+}
+
+export interface AssetGroupBalance__Output {
+  'groupKey': (Buffer);
+  'balance': (string);
+}

--- a/src/types/tarorpc/AssetHumanReadable.ts
+++ b/src/types/tarorpc/AssetHumanReadable.ts
@@ -1,0 +1,24 @@
+// Original file: protos/taro.proto
+
+import type { AssetType as _tarorpc_AssetType } from '../tarorpc/AssetType';
+import type { Long } from '@grpc/proto-loader';
+
+export interface AssetHumanReadable {
+  'id'?: (Buffer | Uint8Array | string);
+  'amount'?: (number | string | Long);
+  'lockTime'?: (number);
+  'relativeLockTime'?: (number);
+  'tag'?: (string);
+  'metaData'?: (Buffer | Uint8Array | string);
+  'type'?: (_tarorpc_AssetType | keyof typeof _tarorpc_AssetType);
+}
+
+export interface AssetHumanReadable__Output {
+  'id': (Buffer);
+  'amount': (string);
+  'lockTime': (number);
+  'relativeLockTime': (number);
+  'tag': (string);
+  'metaData': (Buffer);
+  'type': (keyof typeof _tarorpc_AssetType);
+}

--- a/src/types/tarorpc/GroupedAssets.ts
+++ b/src/types/tarorpc/GroupedAssets.ts
@@ -1,0 +1,11 @@
+// Original file: protos/taro.proto
+
+import type { AssetHumanReadable as _tarorpc_AssetHumanReadable, AssetHumanReadable__Output as _tarorpc_AssetHumanReadable__Output } from '../tarorpc/AssetHumanReadable';
+
+export interface GroupedAssets {
+  'assets'?: (_tarorpc_AssetHumanReadable)[];
+}
+
+export interface GroupedAssets__Output {
+  'assets': (_tarorpc_AssetHumanReadable__Output)[];
+}

--- a/src/types/tarorpc/ListBalancesRequest.ts
+++ b/src/types/tarorpc/ListBalancesRequest.ts
@@ -3,16 +3,16 @@
 
 export interface ListBalancesRequest {
   'assetId'?: (boolean);
-  'famKey'?: (boolean);
+  'groupKey'?: (boolean);
   'assetFilter'?: (Buffer | Uint8Array | string);
-  'familyKeyFilter'?: (Buffer | Uint8Array | string);
-  'groupBy'?: "assetId"|"famKey";
+  'groupKeyFilter'?: (Buffer | Uint8Array | string);
+  'groupBy'?: "assetId"|"groupKey";
 }
 
 export interface ListBalancesRequest__Output {
   'assetId'?: (boolean);
-  'famKey'?: (boolean);
+  'groupKey'?: (boolean);
   'assetFilter': (Buffer);
-  'familyKeyFilter': (Buffer);
-  'groupBy': "assetId"|"famKey";
+  'groupKeyFilter': (Buffer);
+  'groupBy': "assetId"|"groupKey";
 }

--- a/src/types/tarorpc/ListBalancesResponse.ts
+++ b/src/types/tarorpc/ListBalancesResponse.ts
@@ -1,14 +1,14 @@
 // Original file: protos/taro.proto
 
 import type { AssetBalance as _tarorpc_AssetBalance, AssetBalance__Output as _tarorpc_AssetBalance__Output } from '../tarorpc/AssetBalance';
-import type { AssetFamilyBalance as _tarorpc_AssetFamilyBalance, AssetFamilyBalance__Output as _tarorpc_AssetFamilyBalance__Output } from '../tarorpc/AssetFamilyBalance';
+import type { AssetGroupBalance as _tarorpc_AssetGroupBalance, AssetGroupBalance__Output as _tarorpc_AssetGroupBalance__Output } from '../tarorpc/AssetGroupBalance';
 
 export interface ListBalancesResponse {
   'assetBalances'?: ({[key: string]: _tarorpc_AssetBalance});
-  'assetFamilyBalances'?: ({[key: string]: _tarorpc_AssetFamilyBalance});
+  'assetGroupBalances'?: ({[key: string]: _tarorpc_AssetGroupBalance});
 }
 
 export interface ListBalancesResponse__Output {
   'assetBalances': ({[key: string]: _tarorpc_AssetBalance__Output});
-  'assetFamilyBalances': ({[key: string]: _tarorpc_AssetFamilyBalance__Output});
+  'assetGroupBalances': ({[key: string]: _tarorpc_AssetGroupBalance__Output});
 }

--- a/src/types/tarorpc/ListGroupsRequest.ts
+++ b/src/types/tarorpc/ListGroupsRequest.ts
@@ -1,0 +1,8 @@
+// Original file: protos/taro.proto
+
+
+export interface ListGroupsRequest {
+}
+
+export interface ListGroupsRequest__Output {
+}

--- a/src/types/tarorpc/ListGroupsResponse.ts
+++ b/src/types/tarorpc/ListGroupsResponse.ts
@@ -1,0 +1,11 @@
+// Original file: protos/taro.proto
+
+import type { GroupedAssets as _tarorpc_GroupedAssets, GroupedAssets__Output as _tarorpc_GroupedAssets__Output } from '../tarorpc/GroupedAssets';
+
+export interface ListGroupsResponse {
+  'groups'?: ({[key: string]: _tarorpc_GroupedAssets});
+}
+
+export interface ListGroupsResponse__Output {
+  'groups': ({[key: string]: _tarorpc_GroupedAssets__Output});
+}

--- a/src/types/tarorpc/ListUtxosRequest.ts
+++ b/src/types/tarorpc/ListUtxosRequest.ts
@@ -1,0 +1,8 @@
+// Original file: protos/taro.proto
+
+
+export interface ListUtxosRequest {
+}
+
+export interface ListUtxosRequest__Output {
+}

--- a/src/types/tarorpc/ListUtxosResponse.ts
+++ b/src/types/tarorpc/ListUtxosResponse.ts
@@ -1,0 +1,11 @@
+// Original file: protos/taro.proto
+
+import type { ManagedUtxo as _tarorpc_ManagedUtxo, ManagedUtxo__Output as _tarorpc_ManagedUtxo__Output } from '../tarorpc/ManagedUtxo';
+
+export interface ListUtxosResponse {
+  'managedUtxos'?: ({[key: string]: _tarorpc_ManagedUtxo});
+}
+
+export interface ListUtxosResponse__Output {
+  'managedUtxos': ({[key: string]: _tarorpc_ManagedUtxo__Output});
+}

--- a/src/types/tarorpc/ManagedUtxo.ts
+++ b/src/types/tarorpc/ManagedUtxo.ts
@@ -1,0 +1,20 @@
+// Original file: protos/taro.proto
+
+import type { Asset as _tarorpc_Asset, Asset__Output as _tarorpc_Asset__Output } from '../tarorpc/Asset';
+import type { Long } from '@grpc/proto-loader';
+
+export interface ManagedUtxo {
+  'outPoint'?: (string);
+  'amtSat'?: (number | string | Long);
+  'internalKey'?: (Buffer | Uint8Array | string);
+  'taroRoot'?: (Buffer | Uint8Array | string);
+  'assets'?: (_tarorpc_Asset)[];
+}
+
+export interface ManagedUtxo__Output {
+  'outPoint': (string);
+  'amtSat': (string);
+  'internalKey': (Buffer);
+  'taroRoot': (Buffer);
+  'assets': (_tarorpc_Asset__Output)[];
+}

--- a/src/types/tarorpc/NewAddrRequest.ts
+++ b/src/types/tarorpc/NewAddrRequest.ts
@@ -4,12 +4,12 @@ import type { Long } from '@grpc/proto-loader';
 
 export interface NewAddrRequest {
   'genesisBootstrapInfo'?: (Buffer | Uint8Array | string);
-  'famKey'?: (Buffer | Uint8Array | string);
+  'groupKey'?: (Buffer | Uint8Array | string);
   'amt'?: (number | string | Long);
 }
 
 export interface NewAddrRequest__Output {
   'genesisBootstrapInfo': (Buffer);
-  'famKey': (Buffer);
+  'groupKey': (Buffer);
   'amt': (string);
 }

--- a/src/types/tarorpc/Taro.ts
+++ b/src/types/tarorpc/Taro.ts
@@ -15,8 +15,12 @@ import type { ListAssetRequest as _tarorpc_ListAssetRequest, ListAssetRequest__O
 import type { ListAssetResponse as _tarorpc_ListAssetResponse, ListAssetResponse__Output as _tarorpc_ListAssetResponse__Output } from '../tarorpc/ListAssetResponse';
 import type { ListBalancesRequest as _tarorpc_ListBalancesRequest, ListBalancesRequest__Output as _tarorpc_ListBalancesRequest__Output } from '../tarorpc/ListBalancesRequest';
 import type { ListBalancesResponse as _tarorpc_ListBalancesResponse, ListBalancesResponse__Output as _tarorpc_ListBalancesResponse__Output } from '../tarorpc/ListBalancesResponse';
+import type { ListGroupsRequest as _tarorpc_ListGroupsRequest, ListGroupsRequest__Output as _tarorpc_ListGroupsRequest__Output } from '../tarorpc/ListGroupsRequest';
+import type { ListGroupsResponse as _tarorpc_ListGroupsResponse, ListGroupsResponse__Output as _tarorpc_ListGroupsResponse__Output } from '../tarorpc/ListGroupsResponse';
 import type { ListTransfersRequest as _tarorpc_ListTransfersRequest, ListTransfersRequest__Output as _tarorpc_ListTransfersRequest__Output } from '../tarorpc/ListTransfersRequest';
 import type { ListTransfersResponse as _tarorpc_ListTransfersResponse, ListTransfersResponse__Output as _tarorpc_ListTransfersResponse__Output } from '../tarorpc/ListTransfersResponse';
+import type { ListUtxosRequest as _tarorpc_ListUtxosRequest, ListUtxosRequest__Output as _tarorpc_ListUtxosRequest__Output } from '../tarorpc/ListUtxosRequest';
+import type { ListUtxosResponse as _tarorpc_ListUtxosResponse, ListUtxosResponse__Output as _tarorpc_ListUtxosResponse__Output } from '../tarorpc/ListUtxosResponse';
 import type { MintAssetRequest as _tarorpc_MintAssetRequest, MintAssetRequest__Output as _tarorpc_MintAssetRequest__Output } from '../tarorpc/MintAssetRequest';
 import type { MintAssetResponse as _tarorpc_MintAssetResponse, MintAssetResponse__Output as _tarorpc_MintAssetResponse__Output } from '../tarorpc/MintAssetResponse';
 import type { NewAddrRequest as _tarorpc_NewAddrRequest, NewAddrRequest__Output as _tarorpc_NewAddrRequest__Output } from '../tarorpc/NewAddrRequest';
@@ -93,6 +97,15 @@ export interface TaroClient extends grpc.Client {
   listBalances(argument: _tarorpc_ListBalancesRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_tarorpc_ListBalancesResponse__Output>): grpc.ClientUnaryCall;
   listBalances(argument: _tarorpc_ListBalancesRequest, callback: grpc.requestCallback<_tarorpc_ListBalancesResponse__Output>): grpc.ClientUnaryCall;
   
+  ListGroups(argument: _tarorpc_ListGroupsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_tarorpc_ListGroupsResponse__Output>): grpc.ClientUnaryCall;
+  ListGroups(argument: _tarorpc_ListGroupsRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_tarorpc_ListGroupsResponse__Output>): grpc.ClientUnaryCall;
+  ListGroups(argument: _tarorpc_ListGroupsRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_tarorpc_ListGroupsResponse__Output>): grpc.ClientUnaryCall;
+  ListGroups(argument: _tarorpc_ListGroupsRequest, callback: grpc.requestCallback<_tarorpc_ListGroupsResponse__Output>): grpc.ClientUnaryCall;
+  listGroups(argument: _tarorpc_ListGroupsRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_tarorpc_ListGroupsResponse__Output>): grpc.ClientUnaryCall;
+  listGroups(argument: _tarorpc_ListGroupsRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_tarorpc_ListGroupsResponse__Output>): grpc.ClientUnaryCall;
+  listGroups(argument: _tarorpc_ListGroupsRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_tarorpc_ListGroupsResponse__Output>): grpc.ClientUnaryCall;
+  listGroups(argument: _tarorpc_ListGroupsRequest, callback: grpc.requestCallback<_tarorpc_ListGroupsResponse__Output>): grpc.ClientUnaryCall;
+  
   ListTransfers(argument: _tarorpc_ListTransfersRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_tarorpc_ListTransfersResponse__Output>): grpc.ClientUnaryCall;
   ListTransfers(argument: _tarorpc_ListTransfersRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_tarorpc_ListTransfersResponse__Output>): grpc.ClientUnaryCall;
   ListTransfers(argument: _tarorpc_ListTransfersRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_tarorpc_ListTransfersResponse__Output>): grpc.ClientUnaryCall;
@@ -101,6 +114,15 @@ export interface TaroClient extends grpc.Client {
   listTransfers(argument: _tarorpc_ListTransfersRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_tarorpc_ListTransfersResponse__Output>): grpc.ClientUnaryCall;
   listTransfers(argument: _tarorpc_ListTransfersRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_tarorpc_ListTransfersResponse__Output>): grpc.ClientUnaryCall;
   listTransfers(argument: _tarorpc_ListTransfersRequest, callback: grpc.requestCallback<_tarorpc_ListTransfersResponse__Output>): grpc.ClientUnaryCall;
+  
+  ListUtxos(argument: _tarorpc_ListUtxosRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_tarorpc_ListUtxosResponse__Output>): grpc.ClientUnaryCall;
+  ListUtxos(argument: _tarorpc_ListUtxosRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_tarorpc_ListUtxosResponse__Output>): grpc.ClientUnaryCall;
+  ListUtxos(argument: _tarorpc_ListUtxosRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_tarorpc_ListUtxosResponse__Output>): grpc.ClientUnaryCall;
+  ListUtxos(argument: _tarorpc_ListUtxosRequest, callback: grpc.requestCallback<_tarorpc_ListUtxosResponse__Output>): grpc.ClientUnaryCall;
+  listUtxos(argument: _tarorpc_ListUtxosRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_tarorpc_ListUtxosResponse__Output>): grpc.ClientUnaryCall;
+  listUtxos(argument: _tarorpc_ListUtxosRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_tarorpc_ListUtxosResponse__Output>): grpc.ClientUnaryCall;
+  listUtxos(argument: _tarorpc_ListUtxosRequest, options: grpc.CallOptions, callback: grpc.requestCallback<_tarorpc_ListUtxosResponse__Output>): grpc.ClientUnaryCall;
+  listUtxos(argument: _tarorpc_ListUtxosRequest, callback: grpc.requestCallback<_tarorpc_ListUtxosResponse__Output>): grpc.ClientUnaryCall;
   
   MintAsset(argument: _tarorpc_MintAssetRequest, metadata: grpc.Metadata, options: grpc.CallOptions, callback: grpc.requestCallback<_tarorpc_MintAssetResponse__Output>): grpc.ClientUnaryCall;
   MintAsset(argument: _tarorpc_MintAssetRequest, metadata: grpc.Metadata, callback: grpc.requestCallback<_tarorpc_MintAssetResponse__Output>): grpc.ClientUnaryCall;
@@ -173,7 +195,11 @@ export interface TaroHandlers extends grpc.UntypedServiceImplementation {
   
   ListBalances: grpc.handleUnaryCall<_tarorpc_ListBalancesRequest__Output, _tarorpc_ListBalancesResponse>;
   
+  ListGroups: grpc.handleUnaryCall<_tarorpc_ListGroupsRequest__Output, _tarorpc_ListGroupsResponse>;
+  
   ListTransfers: grpc.handleUnaryCall<_tarorpc_ListTransfersRequest__Output, _tarorpc_ListTransfersResponse>;
+  
+  ListUtxos: grpc.handleUnaryCall<_tarorpc_ListUtxosRequest__Output, _tarorpc_ListUtxosResponse>;
   
   MintAsset: grpc.handleUnaryCall<_tarorpc_MintAssetRequest__Output, _tarorpc_MintAssetResponse>;
   
@@ -197,7 +223,9 @@ export interface TaroDefinition extends grpc.ServiceDefinition {
   ImportProof: MethodDefinition<_tarorpc_ImportProofRequest, _tarorpc_ImportProofResponse, _tarorpc_ImportProofRequest__Output, _tarorpc_ImportProofResponse__Output>
   ListAssets: MethodDefinition<_tarorpc_ListAssetRequest, _tarorpc_ListAssetResponse, _tarorpc_ListAssetRequest__Output, _tarorpc_ListAssetResponse__Output>
   ListBalances: MethodDefinition<_tarorpc_ListBalancesRequest, _tarorpc_ListBalancesResponse, _tarorpc_ListBalancesRequest__Output, _tarorpc_ListBalancesResponse__Output>
+  ListGroups: MethodDefinition<_tarorpc_ListGroupsRequest, _tarorpc_ListGroupsResponse, _tarorpc_ListGroupsRequest__Output, _tarorpc_ListGroupsResponse__Output>
   ListTransfers: MethodDefinition<_tarorpc_ListTransfersRequest, _tarorpc_ListTransfersResponse, _tarorpc_ListTransfersRequest__Output, _tarorpc_ListTransfersResponse__Output>
+  ListUtxos: MethodDefinition<_tarorpc_ListUtxosRequest, _tarorpc_ListUtxosResponse, _tarorpc_ListUtxosRequest__Output, _tarorpc_ListUtxosResponse__Output>
   MintAsset: MethodDefinition<_tarorpc_MintAssetRequest, _tarorpc_MintAssetResponse, _tarorpc_MintAssetRequest__Output, _tarorpc_MintAssetResponse__Output>
   NewAddr: MethodDefinition<_tarorpc_NewAddrRequest, _tarorpc_Addr, _tarorpc_NewAddrRequest__Output, _tarorpc_Addr__Output>
   QueryAddrs: MethodDefinition<_tarorpc_QueryAddrRequest, _tarorpc_QueryAddrResponse, _tarorpc_QueryAddrRequest__Output, _tarorpc_QueryAddrResponse__Output>


### PR DESCRIPTION
Updates the `taro.proto` file and re-generate the types using the current `master` branch (commit https://github.com/lightninglabs/taro/commit/ddb0e0d0c9f73800b94b710d4b279e2f0fa5dc72).